### PR TITLE
added BigDecimal.unscaledLong(decimals: Int)

### DIFF
--- a/wavesplatform/src/main/java/com/wavesplatform/sdk/utils/_NumberExt.kt
+++ b/wavesplatform/src/main/java/com/wavesplatform/sdk/utils/_NumberExt.kt
@@ -1,0 +1,8 @@
+package com.wavesplatform.sdk.utils
+
+import java.math.BigDecimal
+import java.math.RoundingMode
+
+fun BigDecimal.unscaledLong(decimals: Int): Long {
+    return setScale(decimals, RoundingMode.HALF_EVEN).unscaledValue().toLong()
+}


### PR DESCRIPTION
 method that scales BigDecimal to desired precision and returns its unscaled value