### PR TITLE
Update InvokeScriptTransaction.kt

### DIFF
--- a/wavesplatform/src/main/java/com/wavesplatform/sdk/model/request/node/InvokeScriptTransaction.kt
+++ b/wavesplatform/src/main/java/com/wavesplatform/sdk/model/request/node/InvokeScriptTransaction.kt
@@ -147,11 +147,11 @@ class InvokeScriptTransaction(
                 } else {
                     SignUtil.arrayOption(paymentItem.assetId!!)
                 }
-                array = Bytes.concat(array, Bytes.concat(amount, assetId))
+                array = Bytes.concat(array, Bytes.concat(amount, assetId).arrayWithSize())
             }
             val lengthBytes = Shorts.toByteArray(payment.size.toShort())
-
-            return Bytes.concat(lengthBytes, array.arrayWithSize())
+            
+            return Bytes.concat(lengthBytes, array)
         } else {
             return byteArrayOf(0, 0)
         }


### PR DESCRIPTION
More than one payment fails to validate when arrayWithSize() included after all paymentItems added to bytes array.

If there are two items in payment array arrayWithSize() gives wrong size

Updated version calculates two and more items as following;
[ (array_size) (item_01_size) (item_01) (item_02_size) (item_02)]
Passes proof validation.

Current version calculates two items as following;
[(array_size) (item_01_size + item_02_size) (item_01) (item_02)]
Fails proof validation